### PR TITLE
fix(say): fixes say_mod for cyrillic script

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -111,8 +111,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/say_mod(input, message_mode)
-	var/ending = copytext_char(input, length(input))
-	if(copytext_char(input, length(input) - 1) == "!!")
+	var/ending = copytext(input, length(input))
+	if(copytext(input, length(input) - 1) == "!!")
 		return verb_yell
 	else if(ending == "?")
 		return verb_ask


### PR DESCRIPTION
Asks, yells, hollers и другие штуки. Тлдр - восклицательные и вопросительные знаки снова работают.
